### PR TITLE
take advantage of types and other rust features to refactor

### DIFF
--- a/src/crate_info.rs
+++ b/src/crate_info.rs
@@ -1,121 +1,137 @@
 use crate::Result;
-use clap::{App, Arg, ArgMatches};
-use open;
-use std::env;
+use clap::ArgMatches;
 use std::fs::read_to_string;
 use std::path::Path;
+use std::borrow::Cow;
+use std::env;
 
-/// Structure with information about the crate.
-pub struct CrateInfo {
-    name: String,
-    version: String,
-    query: String,
-    url: String,
-    warning: String,
-    local: bool,
-    std: bool,
+enum CrateSource {
+    Std,
+    Local(String),
+    DocsRs(String),
 }
 
-/// Stores info about a crate.
-impl CrateInfo {
-    /// Creates an object of type CrateInfo.
-    pub fn new(matches: ArgMatches) -> CrateInfo {
-        let name = matches.value_of("crate").unwrap().to_lowercase().clone();
-        let mut crt = CrateInfo {
-            name: name.clone(),
-            version: String::new(),
-            query: String::new(),
-            url: String::new(),
-            warning: String::new(),
-            local: matches.is_present("local"),
-            std: "std".eq_ignore_ascii_case(&name),
-        };
-        if crt.local {
-            crt.warning = "Versioning and querying is not available with local crates.".into();
-            crt.url = format!(
-                "{}/target/doc/{}/index.html",
-                env::current_dir().unwrap().to_str().unwrap(),
-                name
-            );
-        } else {
-            if crt.std {
-                crt.url = format!("https://doc.rust-lang.org")
+impl CrateSource {
+    fn is_local(&self) -> bool {
+        match self {
+            &CrateSource::Local(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Structure with information about the crate.
+pub struct CrateInfo<'a> {
+    source: CrateSource,
+    version: Option<Cow<'a, str>>,
+    query: Option<&'a str>,
+    warning: Option<String>,
+}
+
+pub fn parse_args<'a>(matches: &'a ArgMatches) -> CrateInfo<'a> {
+    let name = matches.value_of("crate").unwrap().to_lowercase();
+    let query = matches.value_of("query");
+
+    let version = if matches.is_present("manifest") {
+        match get_manifest_version(&name) {
+            Ok(version) => Some(Cow::Owned(version)),
+            Err(e) => {
+                eprintln!("{}", e);
+
+                None
+            },
+        }
+    } else {
+        matches.value_of("version").map(|v| Cow::Borrowed(v))
+    };
+
+
+    let (source, warning) = if name == "std" {
+        (CrateSource::Std, None)
+    } else if matches.is_present("local") {
+        (CrateSource::Local(name), if version.is_some() || query.is_some() {
+            Some("Versioning and querying is not available with local crates.".to_owned())
+        } else { None })
+    } else {
+        (CrateSource::DocsRs(name), None)
+    };
+
+    CrateInfo {
+        source, version, query, warning,
+    }
+}
+
+/// Checks if the crate is available locally.
+fn is_locally_available(path: &str) -> bool {
+    Path::new(path).exists()
+}
+
+fn make_url(crinfo: &CrateInfo) -> String {
+    match &crinfo.source {
+        CrateSource::Std => {
+            let base = String::from("https://docs.rs/std/index.html");
+
+            if let Some(query) = crinfo.query {
+                base + &format!("?search={}", query)
             } else {
-                crt.url = format!("https://docs.rs")
+                base
             }
-            if matches.is_present("version") {
-                crt.version = matches.value_of("version").unwrap().parse().unwrap();
-            }
-            if matches.is_present("query") {
-                crt.query = matches.value_of("query").unwrap().parse().unwrap();
-            }
-            if matches.is_present("manifest") {
-                match get_manifest_version(crt.name.clone()) {
-                    Ok(version) => crt.version = version,
-                    Err(e) => eprintln!("{}", e),
-                }
-            }
-            crt.url = match (crt.std, crt.query.is_empty(), crt.version.is_empty()) {
-                (true, true, true) => format!("{}/std/index.html", crt.url),
-                (true, true, false) => format!("{}/{}/std/index.html", crt.url, crt.version),
-                (true, false, true) => {
-                    format!("{}/std/index.html?search={}", crt.url, crt.query)
-                }
-                (true, false, false) => format!(
-                    "{}/{}/std/index.html?search={}",
-                    crt.url, crt.version, crt.query
-                ),
-                (false, true, true) => format!("{}/{}", crt.url, crt.name),
-                (false, true, false) => format!("{}/{}/{}", crt.url, crt.name, crt.version),
-                (false, false, true) => {
-                    format!("{}/{}/?search={}", crt.url, crt.name, crt.query)
-                }
-                (false, false, false) => format!(
-                    "{}/{}/{}/{}/?search={}",
-                    crt.url, crt.name, crt.version, crt.name, crt.query
-                ),
+        },
+        CrateSource::Local(name) => {
+            format!("{}/target/doc/{}/index.html", env::current_dir().unwrap().to_str().unwrap(), name)
+        },
+        CrateSource::DocsRs(name) => {
+            let base = if let Some(version) = crinfo.version.as_ref() {
+                format!("https://docs.rs/{}/{}", name, version)
+            } else {
+                format!("https://docs.rs/{}", name)
+            };
+
+            if let Some(query) = crinfo.query {
+                base + &format!("?search={}", query)
+            } else {
+                base
             }
         }
-        crt
     }
-    /// Checks if the crate is available locally.
-    fn is_locally_available(&self) -> bool {
-        Path::new(self.url.as_str()).exists()
-    }
-    /// Opens the crate's documentation.
-    pub fn open(&self) -> Result<()> {
-        match open::that(&*self.url) {
-            Ok(_) => {
-                Ok(
-                    if self.std {
-                        println!(
-                            "\x1B[32m\n||| The Standard Library {}||| \n{}\x1B[32m",
-                            self.version, self.warning
-                        )
-                    } else {
-                        println!(
-                            "\x1B[32m\n||| The Book Of {} {}|||\n{}\x1B[32m",
-                            first_letter_to_upper(self.name.as_str()),
-                            self.version,
-                            self.warning
-                        )
-                    }
-                )
+}
+
+/// Opens the crate's documentation.
+pub fn open(crinfo: CrateInfo) -> Result<()> {
+    let url = make_url(&crinfo);
+
+    match open::that(&url) {
+        Ok(_) => {
+            match crinfo.source {
+                CrateSource::Std => {
+                    println!("\x1B[32m\n||| The Standard Library ||| \n\x1B[32m");
+                },
+                CrateSource::Local(name) | CrateSource::DocsRs(name) => {
+                    println!(
+                        "\x1B[32m\n||| The Book Of {} {}|||\n{}\x1B[32m",
+                        first_letter_to_upper(&name),
+                        crinfo.version.unwrap_or_else(|| "".into()),
+                        crinfo.warning.unwrap_or_else(|| "".into()),
+                    );
+                },
             }
-            Err(e) => {
-                if self.local && !self.is_locally_available() {
-                    println!("The crate is not available locally");
-                } else {
-                    println!("Seems like you've lost your way, 学生, try again.");
-                }
-                Err(Box::new(e))
+
+            Ok(())
+        }
+        Err(e) => {
+            if crinfo.source.is_local() && !is_locally_available(&url) {
+                println!("The crate is not available locally");
+            } else {
+                println!("Seems like you've lost your way, 学生, try again.");
             }
+
+            Err(Box::new(e))
         }
     }
 }
 
 /// Get manifest version from Cargo.toml
-fn get_manifest_version(name: String) -> std::io::Result<String> {
+fn get_manifest_version(name: &str) -> std::io::Result<String> {
     let toml = format!("{}/{}", std::env::current_dir()?.display(), "Cargo.toml");
     let version: String = read_to_string(toml)?
         .lines()
@@ -133,52 +149,14 @@ fn first_letter_to_upper(c: &str) -> String {
     }
 }
 
-#[test]
-fn test_first_letter_to_upper() {
-    assert_eq!(first_letter_to_upper("crate"), "Crate");
-    assert_eq!(first_letter_to_upper("c"), "C");
-    assert_eq!(first_letter_to_upper(""), "");
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Creates an object of type ArgMatches with the structure of the CLI.
-pub fn parse_args() -> ArgMatches<'static> {
-    App::new("Sensei")
-        .version("0.2.7")
-        .author("Eduardo F. <edfloreshz@gmail.com>")
-        .about("Opens the documentation for any crate.")
-        .arg(
-            Arg::with_name("crate")
-                .help("What crate do you need help with, 学生?")
-                .short("c")
-                .long("crate")
-                .required(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name("local")
-                .help("Tries to open local documentation.")
-                .short("l")
-                .long("local"),
-        )
-        .arg(
-            Arg::with_name("version")
-                .help("Opens documentation for a specific version.")
-                .short("v")
-                .long("version")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("query")
-                .help("Specifies query to search documentation.")
-                .short("q")
-                .long("query")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("manifest")
-                .help("Looks up the version in Cargo.toml")
-                .short("m")
-                .long("manifest"),
-        )
-        .get_matches()
+    #[test]
+    fn test_first_letter_to_upper() {
+        assert_eq!(first_letter_to_upper("crate"), "Crate");
+        assert_eq!(first_letter_to_upper("c"), "C");
+        assert_eq!(first_letter_to_upper(""), "");
+    }
 }

--- a/src/crate_info.rs
+++ b/src/crate_info.rs
@@ -76,12 +76,10 @@ fn is_locally_available(path: &str) -> bool {
 fn make_url(crate_info: &CrateInfo) -> String {
     match &crate_info.source {
         CrateSource::Std => {
-            let mut base = String::from("https://doc.rust-lang.org/");
-
-            base = if let Some(version) = &crate_info.version {
-                base + &format!("{}/std/", version)
+            let base = if let Some(version) = &crate_info.version {
+                format!("https://doc.rust-lang.org/{}/std/", version)
             } else {
-                base + &format!("stable/std/")
+                format!("https://doc.rust-lang.org/stable/std/")
             };
 
             if let Some(query) = crate_info.query {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod crate_info;
-use crate_info::{parse_args, open};
-use std::error::Error;
 use clap::{App, Arg};
+use crate_info::{open, parse_args};
+use std::error::Error;
 
 pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    let crinfo = parse_args(&matches);
+    let crate_info = parse_args(&matches);
 
-    open(crinfo)
+    open(crate_info)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod crate_info;
-use crate_info::{parse_args, CrateInfo};
+use crate_info::{parse_args, open};
 use std::error::Error;
+use clap::{App, Arg};
 
 pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
@@ -35,5 +36,47 @@ pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 /// $ sensei serde -m
 /// ```
 fn main() -> Result<()> {
-    CrateInfo::new(parse_args()).open()
+    let matches = App::new("Sensei")
+        .version("0.2.7")
+        .author("Eduardo F. <edfloreshz@gmail.com>")
+        .about("Opens the documentation for any crate.")
+        .arg(
+            Arg::with_name("crate")
+                .help("What crate do you need help with, 学生?")
+                .short("c")
+                .long("crate")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("local")
+                .help("Tries to open local documentation.")
+                .short("l")
+                .long("local"),
+        )
+        .arg(
+            Arg::with_name("version")
+                .help("Opens documentation for a specific version.")
+                .short("v")
+                .long("version")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("query")
+                .help("Specifies query to search documentation.")
+                .short("q")
+                .long("query")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("manifest")
+                .help("Looks up the version in Cargo.toml")
+                .short("m")
+                .long("manifest"),
+        )
+        .get_matches();
+
+    let crinfo = parse_args(&matches);
+
+    open(crinfo)
 }


### PR DESCRIPTION
Este PR no es necesariamente para hacérsele merge (aunque probablemente sea buena idea). Es más que nada una exploración de lo que podría ser una estructura factible. Los detalles importantes se conservan, pero el flujo en general cambia:

* exploré un poco la idea de usar funciones libres en lugar de funciones asociadas a la estructura CrateInfo. Al final de cuentas no hay realmente ninguna razón para que estas funciones le "pertenezcan" a CrateInfo, son solamente funciones que hacen cosas.
* Ya no hay ni un solo clone. Para esto se usan dos cosas. La primera es el hecho de que el ArgMatches almacena referencias a los argumentos pasados por línea de comandos, que tienen un tiempo de vida `'static`. La segunda es `std::borrow::Cow` pues la versión puede venir de dos lugares diferentes: la linea de comandos y el Cargo.toml,
* Se explora un poco el uso de `Option`. Por ejemplo para la versión y el query, estos son tipos de datos fundamentalmente opcionales. Pueden o no estar, así que Option es una buena forma de manejarlos en vez de un string vacío o no.
* Se explora un poco el uso de enums. La documentación que se abre es de una de tres fuentes, y no pueden ocurrir dos al mismo tiempo. Eso es una oportunidad perfecta para meter un enum, que encodea en el sistema de tipos la imposibilidad de tener dos escenarios traslapándose.

y bueno, escribí este código mientras estaba en una junta aburrida. Ahora si que "en mi máquina funciona", jeje. Como decía arriba, no pretendo que se le haga merge, son un chingo de cambios. Más bien es para mostrar otra forma posible de atacar este problema.

Saludos!